### PR TITLE
Support arbitrary CSS styling via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A custom digital clock card for Home Assistant
 | timeZone          | string  | **Optional** | Time zone to use. For example `Europe/Berlin` | time zone set in your home assistant profile otherwise your browser time zone |
 | firstLineFormat &#124; timeFormat   | object &#124; string | **Optional** | Format of first line           | { hour: '2-digit', minute: '2-digit' } |
 | secondLineFormat &#124; dateFormat | object  &#124; string  | **Optional** | Format of second line        | { weekday: 'short', day: '2-digit', month: 'short' } |
+| firstLineStyle | map  | **Optional** | CSS Style properties for first line        | { font-size: 4em, text-align: left } |
+| secondLineStyle | map  | **Optional** | CSS Style properties for second line        | { font-size: 4em, text-align: left } |
 
 If `firstLineFormat` respectively `secondLineFormat` is a string, it can be every format, which is valid in Luxon.
 See: [https://moment.github.io/luxon/#/formatting?id=toformat](https://moment.github.io/luxon/#/formatting?id=toformat)
@@ -36,6 +38,26 @@ dateFormat:
 timeFormat:
   hour: '2-digit'
   minute: '2-digit'
+```
+
+# Example with Styling
+```
+type: 'custom:digital-clock'
+dateFormat:
+  weekday: 'long'
+  day: '2-digit'
+  month: 'short'
+timeFormat:
+  hour: '2-digit'
+  minute: '2-digit'
+firstLineStyle:
+  font-size: 4em
+  font-family: 'Roboto Condensed, sans-serif'
+  font-weight: 400
+secondLineStyle:
+  font-size: 2em
+  font-family: 'Roboto Condensed, sans-serif'
+  font-weight: 300
 ```
 
 [license-shield]: https://img.shields.io/github/license/wassy92x/lovelace-digital-clock.svg?style=for-the-badge

--- a/src/DigitalClock.ts
+++ b/src/DigitalClock.ts
@@ -35,6 +35,8 @@ export class DigitalClock extends LitElement {
     @property({attribute: false}) public hass!: HomeAssistant;
     @state() private _firstLine = '';
     @state() private _secondLine = '';
+    @state() private _firstLineElement?: HTMLElement;
+    @state() private _secondLineElement?: HTMLElement;  
     @state() private _config?: IDigitalClockConfig;
     @state() private _interval = 1000;
     private _intervalId?: number;
@@ -47,6 +49,11 @@ export class DigitalClock extends LitElement {
             this._config.secondLineFormat = this._config.dateFormat;
         if (this._config.interval !== this._interval)
             this._interval = this._config.interval ?? 1000;
+
+        this._firstLineElement = this._createStyledElement('first-line', this._config?.firstLineStyle || {});
+        this._firstLineElement.innerText = this._firstLine;
+        this._secondLineElement = this._createStyledElement('second-line', this._config?.secondLineStyle || {});
+        this._secondLineElement.innerText = this._secondLine;        
     }
 
     protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -71,6 +78,15 @@ export class DigitalClock extends LitElement {
     public connectedCallback(): void {
         super.connectedCallback();
         this._startInterval();
+    }
+
+    private _createStyledElement(className: string, lineStyle: { [name: string]: string }): HTMLElement {
+        const element = document.createElement('span');
+        element.className = className;
+        for (const prop in lineStyle) {
+          element.style.setProperty(prop, lineStyle[prop]);
+        }
+        return element;
     }
 
     private _startInterval(): void {
@@ -121,10 +137,18 @@ export class DigitalClock extends LitElement {
         else
             secondLine = dateTime.toLocaleString(this._config?.secondLineFormat ?? { weekday: 'short', day: '2-digit', month: 'short' });
 
-        if (firstLine !== this._firstLine)
+        if (firstLine !== this._firstLine) {
             this._firstLine = firstLine;
-        if (secondLine !== this._secondLine)
+            if (this._firstLineElement) {
+                this._firstLineElement.innerText = firstLine;
+            }
+        }
+        if (secondLine !== this._secondLine) {
             this._secondLine = secondLine;
+            if (this._secondLineElement) {
+                this._secondLineElement.innerText = secondLine;
+            }
+        }
     }
 
     public disconnectedCallback(): void {
@@ -135,8 +159,8 @@ export class DigitalClock extends LitElement {
     protected render(): TemplateResult | void {
         return html`
             <ha-card>
-                <span class="first-line">${this._firstLine}</span>
-                <span class="second-line">${this._secondLine}</span>
+              ${this._firstLineElement}
+              ${this._secondLineElement}
             </ha-card>
         `;
     }

--- a/src/IDigitalClockConfig.ts
+++ b/src/IDigitalClockConfig.ts
@@ -9,4 +9,6 @@ export default interface IDigitalClockConfig {
     locale?: string;
     firstLineFormat?: (LocaleOptions & DateTimeFormatOptions) | string;
     secondLineFormat?: (LocaleOptions & DateTimeFormatOptions) | string;
+    firstLineStyle?: {[name: string]: string};
+    secondLineStyle?: {[name: string]: string};
 }


### PR DESCRIPTION
Following the pattern from the the Picture Elements Card [link](https://www.home-assistant.io/dashboards/picture-elements/#style).
Add configuration options to allow specifying CSS Styling to each line individually.

This is currently achievable via card-mod, but specifying styling directly makes this card much more convenient to use while lowering the bar for new users.